### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def download_files_from_playlist(m3u8list):
 
     segment_map_absolute_url = None
     if m3u8list.segment_map:
-        segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map["uri"])
+        segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map[0].uri)
     if segment_map_absolute_url:
         DOWNLOADER.download_one_file(segment_map_absolute_url)
 


### PR DESCRIPTION
Was getting errors with parsing segment_map:
  File "c:\Projects\hls-downloader-master\hls-downloader-master\main.py", line 59, in download_files_from_playlist
    segment_map_absolute_url = urlparse.urljoin(m3u8list.base_uri, m3u8list.segment_map["uri"])
TypeError: list indices must be integers or slices, not str

Have not looked in too much detail, but when debugging it seemed that the segment_map is a single item list containing the "uri" key. 